### PR TITLE
Switch Stack Workflow docs from ghstack to gh stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,19 +16,22 @@ Contains the public README, shared GitHub configuration, and organizational asse
 - Body with labels: `Design:`, `Related:`, `Closes #`
 - Keep Markdown lines wrapped at 80 columns and run `nix fmt` before shipping
 
-## Stack
+## Stack Workflow
 
-- 1 commit == 1 PR via ghstack (1 commit is 1 logical atomic change)
-- The commit title **is** the PR title; the commit body **is** the PR body
-- Split work into stacked PRs to keep each PR small and reviewable
-- To pull down an existing stack: `ghstack checkout <PR_NUMBER>`
-- To update a PR: edit files, then `jj squash` (or `git commit --amend`) into the
-  **target commit** of the stack — the one that PR represents; the commit message
-  updates the PR title and body automatically when resubmitted
-- Resubmit with `ghstack` after squashing
-- `ghstack land` on the head PR to land the entire stack
-- Never `gh pr merge` (creates poisoned commits)
-- Never force-push ghstack branches
+- Install the official GitHub extension once: `gh extension install github/gh-stack`
+  (requires GitHub CLI ≥ 2.0; `gh stack` is in public preview and may change).
+- Keep one logical change per PR; split large work into a stack of PRs.
+- Create a stack: `gh stack init`, then `gh stack add` for each new branch, and
+  commit on the active branch. `gh stack view` lists the stack.
+- Submit/update: `gh stack submit` (add `--open` to open PRs, `--auto` to skip
+  prompts). Resubmit after each change to refresh titles, bodies, and branches.
+- Pull down an existing stack: `gh stack checkout <PR_NUMBER>` (also accepts a
+  stack number, PR URL, or branch name).
+- Rebase onto updated trunk: `gh stack rebase` (cascading), then `gh stack submit`.
+- Land a stack: `gh stack merge` (interactive) or
+  `gh stack merge <PR_NUMBER> --yes --squash` to merge up to a PR.
+- Never `gh pr merge` on a stacked PR — only `gh stack merge` lands stacks.
+- Never force-push stack branches; `gh stack` owns the branch pointers.
 
 
 ## Protect `main`


### PR DESCRIPTION
Migrate the Stack Workflow section from ezyang/ghstack (.land, ghstack) to GitHub's first-party gh stack extension.

Related: https://github.com/shikanime-studio/.github/issues/58